### PR TITLE
Add loading state for grids

### DIFF
--- a/src/app/master-view/master-view.component.html
+++ b/src/app/master-view/master-view.component.html
@@ -88,8 +88,15 @@
         </div>
       </div>
       <div class="column-layout group_18">
-        <igx-grid [data]="northwindJasonApiCustomerOrdersCustomerId" primaryKey="orderID" displayDensity="cosy" rowSelection="single" [hideRowSelectors]="true" [allowFiltering]="true" filterMode="excelStyleFilter" class="grid"
-          (selected)="orderSelected($event.cell.row.data.orderID)"
+        <igx-grid [data]="northwindJasonApiCustomerOrdersCustomerId"
+          primaryKey="orderID" displayDensity="cosy"
+          rowSelection="single"
+          cellSelection="none"
+          [hideRowSelectors]="true"
+          [allowFiltering]="true"
+          filterMode="excelStyleFilter" class="grid"
+          [isLoading]="ordersAreLoading"
+          (rowSelectionChanging)="orderSelected($event)"
         >
           <igx-grid-toolbar>
             <igx-grid-toolbar-actions>
@@ -97,7 +104,7 @@
             </igx-grid-toolbar-actions>
             <igx-grid-toolbar-title>Orders</igx-grid-toolbar-title>
           </igx-grid-toolbar>
-          <igx-column header="orderID" field="orderID" dataType="number" [sortable]="true" title="orderID"></igx-column>
+          <igx-column header="orderID" field="orderID" [sortable]="true" title="orderID"></igx-column>
           <igx-column header="customerID" field="customerID" dataType="string" [sortable]="true" title="customerID"></igx-column>
           <igx-column header="employeeID" field="employeeID" dataType="number" [sortable]="true" title="employeeID"></igx-column>
           <igx-column header="orderDate" field="orderDate" dataType="string" [sortable]="true" title="orderDate"></igx-column>
@@ -114,10 +121,13 @@
         </igx-grid>
       </div>
       <div class="column-layout group_18">
-        <span>selectedOrderId: {{selectedOrderId}}</span>
-        <igx-grid [data]="northwindJasonApiCustomerOrderDetailsOrderId" primaryKey="productName" displayDensity="cosy" [allowFiltering]="true" filterMode="excelStyleFilter" class="grid">
+        <igx-grid [data]="northwindJasonApiCustomerOrderDetailsOrderId"
+          primaryKey="productName" displayDensity="cosy"
+          [allowFiltering]="true" filterMode="excelStyleFilter" class="grid"
+          [isLoading]="detailsAreLoading"
+        >
           <igx-grid-toolbar>
-            <igx-grid-toolbar-title>Order details</igx-grid-toolbar-title>
+            <igx-grid-toolbar-title>Order details #{{ selectedOrderId }}</igx-grid-toolbar-title>
           </igx-grid-toolbar>
           <igx-column header="productName" field="productName" dataType="string" [sortable]="true" title="productName"></igx-column>
           <igx-column header="unitPrice" field="unitPrice" dataType="number" [sortable]="true" title="unitPrice"></igx-column>

--- a/src/app/master-view/master-view.component.ts
+++ b/src/app/master-view/master-view.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { IRowSelectionEventArgs } from 'igniteui-angular';
 import { ICustomer, Northwind_JasonService } from '../services/northwind_jason.service';
 
 @Component({
@@ -18,6 +18,8 @@ export class MasterViewComponent implements OnInit {
   }
 
   public selectedOrderId?: number;
+  public ordersAreLoading = true;
+  public detailsAreLoading = true;
 
   constructor(
     private northwind_JasonService: Northwind_JasonService,
@@ -34,21 +36,29 @@ export class MasterViewComponent implements OnInit {
 
   public selectCustomer(customerID: string) {
     this.selectedOrderId = undefined;
-    this.northwindJasonApiCustomerOrdersCustomerId = [];
-    this.northwindJasonApiCustomerOrderDetailsOrderId = [];
+    // this.northwindJasonApiCustomerOrdersCustomerId = [];
+    // this.northwindJasonApiCustomerOrderDetailsOrderId = [];
 
     this.selectedCustomerId = customerID;
     this.loadCustomerData(customerID);
   }
 
   public loadCustomerData(customerID: string) {
-    this.northwind_JasonService.getApiCustomerOrdersCustomerId(customerID).subscribe(data => this.northwindJasonApiCustomerOrdersCustomerId = data);
+    this.ordersAreLoading = true;
+    this.northwind_JasonService.getApiCustomerOrdersCustomerId(customerID).subscribe(data => { 
+      this.northwindJasonApiCustomerOrdersCustomerId = data;
+      this.ordersAreLoading = false;
+      this.detailsAreLoading = false;
+    });
   }
 
-  public orderSelected(orderID: number) {
-    this.northwindJasonApiCustomerOrderDetailsOrderId = [];
-
-    this.selectedOrderId = orderID;
-    this.northwind_JasonService.getApiCustomerOrderDetailsOrderId(orderID).subscribe(data => this.northwindJasonApiCustomerOrderDetailsOrderId = data);
+  public orderSelected(orderID: IRowSelectionEventArgs) {
+    // this.northwindJasonApiCustomerOrderDetailsOrderId = [];
+    this.detailsAreLoading = true;
+    this.selectedOrderId = orderID.newSelection[0];
+    this.northwind_JasonService.getApiCustomerOrderDetailsOrderId(orderID.newSelection[0]).subscribe(data => { 
+      this.northwindJasonApiCustomerOrderDetailsOrderId = data;
+      this.detailsAreLoading = false;
+    });
   }
 }


### PR DESCRIPTION
I think that's the things that are nice enhacements and dont add much code:

- loader for the grids while waiting for data
- display information about the OrderID in grid toolbar, not outside
- disable `cellSelection`. Or vice versa

I noticed two bugs I am going to report:
- loader for first grid is not positioned in the center https://github.com/IgniteUI/igniteui-angular/issues/11732
- selection in the first grid resets page scroll (probably is fixed by https://github.com/IgniteUI/igniteui-angular/pull/11705)